### PR TITLE
Exclude the vendor directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,3 +13,5 @@ collections:
   presentations:
     output: true
     permalink: /presentation/:path/
+
+exclude: [vendor]


### PR DESCRIPTION
According to here, should fix Travis build: https://jekyllrb.com/docs/continuous-integration/
