### PR TITLE
Overhaul external blog posts

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -11,15 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
-        id: rbenv
-
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: "${{ steps.rbenv.outputs.RUBY_VERSION }}"
+      - uses: ruby/setup-ruby@v1
       - run: gem install bundler
-
       - run: bundle install --path vendor/bundle
       - run: bundle exec jekyll build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
-        id: rbenv
-
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: "${{ steps.rbenv.outputs.RUBY_VERSION }}"
+      - uses: ruby/setup-ruby@v1
       - run: gem install bundler
-
       - run: bundle install --path vendor/bundle
       - run: bundle exec jekyll build

--- a/_posts/2012-05-15-using-actionbarsherlock-as-a-base.md
+++ b/_posts/2012-05-15-using-actionbarsherlock-as-a-base.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/using-actionbarsherlock-as-a-base-7be94855009f
+blog_link: https://medium.com/square-corner-blog/using-actionbarsherlock-as-a-base-7be94855009f
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2012-07-02-decoupling-android-apps-with-otto.md
+++ b/_posts/2012-07-02-decoupling-android-apps-with-otto.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/decoupling-android-app-communication-with-otto-a37c22b79990
+blog_link: https://medium.com/square-corner-blog/decoupling-android-app-communication-with-otto-a37c22b79990
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2013-04-03-the-resurrection-of-testing-for-android.md
+++ b/_posts/2013-04-03-the-resurrection-of-testing-for-android.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/the-resurrection-of-testing-for-android-82e3e0c35b41
+blog_link: https://medium.com/square-corner-blog/the-resurrection-of-testing-for-android-82e3e0c35b41
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2013-05-06-seven-days-of-open-source.md
+++ b/_posts/2013-05-06-seven-days-of-open-source.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/seven-days-of-open-source-7a6270f5346b
+blog_link: https://medium.com/square-corner-blog/seven-days-of-open-source-7a6270f5346b
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2013-05-08-mimecraft-javawriter-and-protoparser.md
+++ b/_posts/2013-05-08-mimecraft-javawriter-and-protoparser.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/mimecraft-javawriter-and-protoparser-7a3feaa11d69
+blog_link: https://medium.com/square-corner-blog/mimecraft-javawriter-and-protoparser-7a3feaa11d69
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2013-05-13-easy-http-requests-with-retrofit.md
+++ b/_posts/2013-05-13-easy-http-requests-with-retrofit.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/easy-http-requests-with-retrofit-8c6d45c9bd43
+blog_link: https://medium.com/square-corner-blog/easy-http-requests-with-retrofit-8c6d45c9bd43
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2013-05-14-enhance-your-application-using-picasso.md
+++ b/_posts/2013-05-14-enhance-your-application-using-picasso.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/enhance-your-application-using-picasso-4b2991436b6a
+blog_link: https://medium.com/square-corner-blog/enhance-your-application-using-picasso-4b2991436b6a
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2014-01-20-dynamic-images-with-thumbor.md
+++ b/_posts/2014-01-20-dynamic-images-with-thumbor.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/dynamic-images-with-thumbor-a430a1cfcd87
+blog_link: https://medium.com/square-corner-blog/dynamic-images-with-thumbor-a430a1cfcd87
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2014-05-30-hello-picasso-2.3.md
+++ b/_posts/2014-05-30-hello-picasso-2.3.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/hello-picasso-2-3-a13e23348bef
+blog_link: https://medium.com/square-corner-blog/hello-picasso-2-3-a13e23348bef
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2014-11-21-better-parameterized-tests-with-burst.md
+++ b/_posts/2014-11-21-better-parameterized-tests-with-burst.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/better-parameterized-tests-with-burst-6f17560013a
+blog_link: https://medium.com/square-corner-blog/better-parameterized-tests-with-burst-6f17560013a
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2015-02-25-sqlbrite-a-reactive-database-foundation.md
+++ b/_posts/2015-02-25-sqlbrite-a-reactive-database-foundation.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/sqlbrite-a-reactive-database-foundation-40e3a617866d
+blog_link: https://medium.com/square-corner-blog/sqlbrite-a-reactive-database-foundation-40e3a617866d
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2016-12-02-web-sockets-now-shipping-in-okhttp.md
+++ b/_posts/2016-12-02-web-sockets-now-shipping-in-okhttp.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/web-sockets-now-shipping-in-okhttp-3-5-463a9eec82d1
+blog_link: https://medium.com/square-corner-blog/web-sockets-now-shipping-in-okhttp-3-5-463a9eec82d1
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2017-05-12-square-open-source-loves-kotlin.md
+++ b/_posts/2017-05-12-square-open-source-loves-kotlin.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/square-open-source-loves-kotlin-c57c21710a17
+blog_link: https://medium.com/square-corner-blog/square-open-source-loves-kotlin-c57c21710a17
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2017-05-14-an-optionals-place-in-kotlin.md
+++ b/_posts/2017-05-14-an-optionals-place-in-kotlin.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/an-optionals-place-in-kotlin-17d7b271eefe
+blog_link: https://medium.com/square-corner-blog/an-optionals-place-in-kotlin-17d7b271eefe
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2017-05-16-generating-kotlin-code-with-kotlinpoet.md
+++ b/_posts/2017-05-16-generating-kotlin-code-with-kotlinpoet.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/generating-kotlin-code-with-kotlinpoet-119dc20f74d4
+blog_link: https://medium.com/square-corner-blog/generating-kotlin-code-with-kotlinpoet-119dc20f74d4
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2017-07-13-surfacing-hidden-change-to-pull-requests.md
+++ b/_posts/2017-07-13-surfacing-hidden-change-to-pull-requests.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Square Corner
-permalink: https://medium.com/square-corner-blog/surfacing-hidden-change-to-pull-requests-6a371266e479
+blog_link: https://medium.com/square-corner-blog/surfacing-hidden-change-to-pull-requests-6a371266e479
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/_posts/2018-02-05-introducing-android-ktx.md
+++ b/_posts/2018-02-05-introducing-android-ktx.md
@@ -4,7 +4,8 @@ layout: post
 
 external: true
 blog: Android Developers Blog
-permalink: https://android-developers.googleblog.com/2018/02/introducing-android-ktx-even-sweeter.html
+blog_link: https://android-developers.googleblog.com/2018/02/introducing-android-ktx-even-sweeter.html
+permalink: '' # Disable HTML generation
 
 categories: post
 tags:

--- a/atom.xml
+++ b/atom.xml
@@ -16,10 +16,10 @@ layout: null
  {% for post in site.posts %}
  <entry>
    <title>{{ post.title }}</title>
-   <link href="{% if post.external %}{{ post.permalink }}{% else %}{{ site.url }}{{ post.url }}{% endif %}"/>
+   <link href="{% if post.external %}{{ post.blog_link }}{% else %}{{ site.url }}{{ post.url }}{% endif %}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>{{ site.url }}{{ post.id }}</id>
-   <content type="html">{{ post.content | xml_escape }}</content>
+   <content type="html">{% if post.external %}This post was published externally on {{ post.blog }}. Read it at <a href="{{ post.blog_link }}">{{ post.blog_link }}</a>{% else %}{{ post.content | xml_escape }}{% endif %}</content>
  </entry>
  {% endfor %}
 

--- a/blog.html
+++ b/blog.html
@@ -8,7 +8,7 @@ tab: posts
 {% for post in site.categories.post %}
   <li class="presentation">
     <span class="date">{{ post.date | date: "%Y-%m-%d" }}</span>
-    <a href="{% if post.external %}{{ post.permalink }}{% else %}{{ post.url }}{% endif %}">{% if post.external %}⇖ {% endif %}{{ post.title }}</a>
+    <a href="{% if post.external %}{{ post.blog_link }}{% else %}{{ post.url }}{% endif %}">{% if post.external %}⇖ {% endif %}{{ post.title }}</a>
     {% if post.external %}<small>{{ post.blog }}</small>{% endif %}
   </li>
 {% endfor %}


### PR DESCRIPTION
- Prevent the content from appearing in the RSS/Atom feed and instead point to the external link.
- Prevent the content from rendering to HMTL which can then be indexed by search engines and discovered.