### PR TITLE
Simplify steps and improve build time by enabling bundler cache

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
-      - run: gem install bundler
-      - run: bundle install --path vendor/bundle
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - run: bundle exec jekyll build
 
       - uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
-      - run: gem install bundler
-      - run: bundle install --path vendor/bundle
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - run: bundle exec jekyll build


### PR DESCRIPTION
Hello fellow ASGer! 👋🏽

The `setup-ruby` action has support for caching and automatically running `bundle install`. The changes here use that and should simplify your workflows (removes 2 `run` steps in each workflow). This _should_ result in cutting down your build times by 40 - 50 seconds (based on your most recent runs) after initial caching your gems on the first run.

You can read more about the caching functionality here: https://github.com/ruby/setup-ruby#caching-bundle-install-automatically

I hope this is helpful!