### PR TITLE
Run post.title through xml_escape

### DIFF
--- a/site/atom.xml
+++ b/site/atom.xml
@@ -11,7 +11,7 @@
   </author>
 {% for post in site.posts %}
   <entry>
-    <title>{{ post.title }}</title>
+    <title>{{ post.title | xml_escape }}</title>
     <link href="{% if post.external %}{{ post.blog_link }}{% else %}{{ site.url }}{{ post.url }}{% endif %}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>


### PR DESCRIPTION
The ampersand in the latest post made the atom.xml unhappy with this error [you can see here](https://jakewharton.com/atom.xml).
```
XML Parsing Error: not well-formed
Location: https://jakewharton.com/atom.xml
Line Number 14, Column 21:
    <title>Compose & kotlinx.html</title>
--------------------^
```

This just runs it through the existing filter in `renderer.kt`
```
.withFilter(
			object : Filter("xml_escape") {
				override fun apply(value: Any?, context: TemplateContext, vararg params: Any?): Any {
					val string = super.asString(value, context)
					return StringEscapeUtils.ESCAPE_XML11.translate(string)
				}
			},
		)
```